### PR TITLE
Open setup.py with utf-8 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@
         except ApiError:
             abort(500)
 
-### 👨 Ways to load Credentials (User & Client)
+### Ways to load Credentials (User & Client)
 
     # Instantiate directly
     client = ClientCreds(client_id='aclientid', client_secret='averysecrettoken')
@@ -162,7 +162,7 @@
     client = ClientCreds()
     client.load_from_json(path='full/dir/path', name='name_of_the_json_file')
 
-## 🎶 Resources
+## Resources
 
 - Playback:
   - devices()

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@
         except ApiError:
             abort(500)
 
-### Ways to load Credentials (User & Client)
+### 👨 Ways to load Credentials (User & Client)
 
     # Instantiate directly
     client = ClientCreds(client_id='aclientid', client_secret='averysecrettoken')
@@ -162,7 +162,7 @@
     client = ClientCreds()
     client.load_from_json(path='full/dir/path', name='name_of_the_json_file')
 
-## Resources
+## 🎶 Resources
 
 - Playback:
   - devices()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt', "r") as f:
 with open('test_requirements.txt', "r") as f:
     test_requirements = f.read().splitlines()
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Pyfy was unable to install on my Linux machine because of the emojis used in the long_description (README.md).

`UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 4335: ordinal not in range(128)`

Opening the file as utf-8 fixes this issue and allows pyfy to install successfully.