### PR TITLE
changes to Spotify.play() keyword arguments

### DIFF
--- a/pyfy/sync_client.py
+++ b/pyfy/sync_client.py
@@ -336,44 +336,42 @@ class Spotify(_BaseClient):
 
     @_dispatch_request
     def play(self, *args, **kwargs):
-        """
+        '''
         Starts playback
 
-        Note:
-        
-            Available resource types:
-            
-            - 'track'
-            
-            - 'artist'
-            
-            - 'playlist'
-            
-            - 'podcast'
-            
-            - 'user' 
-            
-            * There might be more
-        
+        Play a list of one or more tracks, or a specific artist, album or playlist.
+        Only one of track_ids, album_id, artist_id, playlist_id should be specified.
+        Start playback at offset_position OR offset_uri, only if artist_id is not being used.
+
         Arguments:
 
-            resource_id (str): 
-            
+            track_ids (list, str):
+
                 * Optional
 
-                * ID of the resource
+                * List containing track ID(s).
 
-            resource_type (str):
-            
+            album_id (str):
+
                 * Optional
 
-                * Type of the resource.
+            artist_id (str):
+
+                * Optional
+
+            playlist_id (str):
+
+                * Optional
 
             device_id (str):
 
                 * Optional
 
-            offset_position (int): 
+            offset_position (int):
+
+                * Optional
+
+            offset_uri (str):
 
                 * Optional
 
@@ -388,7 +386,7 @@ class Spotify(_BaseClient):
         Raises:
 
             pyfy.excs.ApiError:
-        """
+        '''
         return args, kwargs
 
     @_dispatch_request

--- a/pyfy/utils.py
+++ b/pyfy/utils.py
@@ -78,7 +78,7 @@ def _build_full_url(url, query):
 
 
 def _safe_json_dict(data):
-    safe_types = [float, str, int, bool]
+    safe_types = [float, str, int, bool, list]
     safe_json = {}
     for k, v in data.items():
         if type(v) in safe_types:


### PR DESCRIPTION
Also added `offset_uri` to match the Spotify end points. `offset_uri` has to be a track uri and will work with `track_ids`, `album_id`, or `playlist_id`.  Using it with `artist_id` gets rejected by Spotify.