### PR TITLE
Illegal Scope error on examples/oath2.py

### DIFF
--- a/pyfy/creds.py
+++ b/pyfy/creds.py
@@ -29,7 +29,6 @@ ALL_SCOPES = [
     "user-read-playback-state",
     "user-read-currently-playing",
     "user-read-private",  # Users
-    "user-read-birthdate",
     "user-read-email",
     "user-library-read",  # Library
     "user-library-modify",


### PR DESCRIPTION
Upon running [examples/oath2.py](https://github.com/omarryhan/pyfy/blob/master/examples/oauth2.py) I get `Illegal scope` returned from spotify.com on my browser. 

<img width="931" alt="Screen Shot 2019-10-30 at 6 42 48 PM" src="https://user-images.githubusercontent.com/5832225/67888505-23982700-fb45-11e9-8725-e9a506c35279.png">


Looking around I noticed this [issue](https://github.com/spotify/web-api/issues/1322) on the spotify/web-api repo with a comment noting changes to the `user-read-birthdate` scope. It seems as though that scope was [removed](https://developer.spotify.com/documentation/general/guides/scopes/) and running the /authorize redirect url without it all works well. 

As such I have removed the `user-read-birthdate` from the ALL_SCOPES in [pyfy/creds.py](https://github.com/omarryhan/pyfy/compare/master...haykkh:illegal-scope-fix?expand=1#diff-2cdb4867d352e1bb71fb0417bcc32bd3)