### PR TITLE
Fixed playback transfer

### DIFF
--- a/pyfy/base_client.py
+++ b/pyfy/base_client.py
@@ -457,7 +457,7 @@ class _BaseClient:
     def _prep_playback_transfer(self, device_ids, **kwargs):
         url = BASE_URI + "/me/player"
         params = {}
-        data = dict(device_ids=_safe_comma_join_list(device_ids))
+        data = dict(device_ids=[_safe_comma_join_list(device_ids)])
         return self._create_request(
             method="PUT", url=_build_full_url(url, params), json=data
         )


### PR DESCRIPTION
It seems like Spotify changed the behavior for transferring the playback. Sending the device ids for transferring the playback have now to be surrounded by square brackets.

<img width="609" alt="image" src="https://user-images.githubusercontent.com/10659023/98695037-791b2c80-2372-11eb-9ff1-b29544bd5599.png">
